### PR TITLE
Fix fastlane command envs.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,7 +7,7 @@ workflows:
   ci:
     envs:
     - SAMPLE_APP_URL: "https://github.com/bitrise-io/sample-apps-flutter-veggieseasons.git"
-    - BRANCH: master
+    - BRANCH: fastlane-session
     before-run:
     - audit-this-step
     steps:
@@ -48,6 +48,12 @@ workflows:
                 echo "BITRISE_CACHE_INCLUDE_PATHS is empty"
                 exit 1
             fi
+    - path::./:
+        title: Test if Fastlane receives session-based Apple Developer connection
+        inputs:
+        - lane: test_fastlane_session
+        - work_dir: ./
+        - verbose_log: "yes"
 
   fastlane-session-test:
     envs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -29,8 +29,15 @@ workflows:
         - content: |-
             set -ex
             git clone $SAMPLE_APP_URL -b $BRANCH .
+    - path::./:
+        title: Test if Fastlane receives session-based Apple Developer connection
+        inputs:
+        - lane: test_fastlane_session
+        - work_dir: ./
+        - verbose_log: "yes"
     - certificate-and-profile-installer:
     - path::./:
+        title: Test building a Flutter project
         inputs:
         - lane: build
         - work_dir: ./
@@ -48,12 +55,6 @@ workflows:
                 echo "BITRISE_CACHE_INCLUDE_PATHS is empty"
                 exit 1
             fi
-    - path::./:
-        title: Test if Fastlane receives session-based Apple Developer connection
-        inputs:
-        - lane: test_fastlane_session
-        - work_dir: ./
-        - verbose_log: "yes"
 
   fastlane-session-test:
     envs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,7 +7,7 @@ workflows:
   ci:
     envs:
     - SAMPLE_APP_URL: "https://github.com/bitrise-io/sample-apps-flutter-veggieseasons.git"
-    - BRANCH: fastlane-session
+    - BRANCH: master
     before-run:
     - audit-this-step
     steps:

--- a/main.go
+++ b/main.go
@@ -282,7 +282,6 @@ func main() {
 
 	cmd.SetStdout(os.Stdout).SetStderr(os.Stderr)
 	cmd.SetDir(workDir)
-	cmd.AppendEnvs(envs...)
 
 	buildlogPth := ""
 
@@ -290,8 +289,10 @@ func main() {
 		log.Errorf("Failed to create temp dir for fastlane logs, error: %s", err)
 	} else {
 		buildlogPth = tempDir
-		cmd.AppendEnvs("FL_BUILDLOG_PATH=" + buildlogPth)
+		envs = append(envs, "FL_BUILDLOG_PATH="+buildlogPth)
 	}
+
+	cmd.AppendEnvs(envs...)
 
 	deployDir := os.Getenv("BITRISE_DEPLOY_DIR")
 	if deployDir == "" {


### PR DESCRIPTION
Fixes the issue of setting `FASTLANE_SESSION` env var for the Fastlane command.

[command.AppendEnvs](https://github.com/bitrise-io/go-utils/blob/master/command/command.go#L75) was incorrectly used:

```
// AppendEnvs - appends the envs to the current os.Environ()
// Calling this multiple times will NOT appens the envs one by one,
// only the last "envs" set will be appended to os.Environ()!
```

Merge sample app [PR](https://github.com/bitrise-io/sample-apps-flutter-veggieseasons/pull/4) first, it introduces a new lane for testing the presence of `FASTLANE_SESSION`.

If a session-based Apple Developer account not set the [new test case fails](https://app.bitrise.io/build/8d5296d2d18f451e) with this message:

```

Run Fastlane
$ fastlane "test_fastlane_session"
[17:17:27]: Get started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile
[17:17:32]: ------------------------------
[17:17:32]: --- Step: default_platform ---
[17:17:32]: ------------------------------
[17:17:32]: Driving the lane 'ios test_fastlane_session' 🚀
[17:17:32]: ------------------------------------
[17:17:32]: --- Step: bash ./test_session.sh ---
[17:17:32]: ------------------------------------
[17:17:32]: $ bash ./test_session.sh
[17:17:32]: ▸ FASTLANE_SESSION not set
```