### PR TITLE
Export APP_STORE_CONNECT_API_KEY_PATH

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -34,6 +34,7 @@ func FastlaneAuthParams(authConfig appleauth.Credentials) (map[string]string, er
 		if authConfig.AppleID.Password != "" {
 			envs["FASTLANE_PASSWORD"] = authConfig.AppleID.Password
 			envs["DELIVER_PASSWORD"] = authConfig.AppleID.Password
+			envs["PILOT_PASSWORD"] = authConfig.AppleID.Password
 		}
 		if authConfig.AppleID.Session != "" {
 			envs["FASTLANE_SESSION"] = authConfig.AppleID.Session

--- a/credentials.go
+++ b/credentials.go
@@ -63,6 +63,9 @@ func FastlaneAuthParams(authConfig appleauth.Credentials) (map[string]string, er
 		}
 
 		envs["APP_STORE_CONNECT_API_KEY_PATH"] = fastlaneAuthFile
+		// these seem redundant and might become obsolete soon
+		envs["DELIVER_API_KEY_PATH"] = fastlaneAuthFile
+		envs["PILOT_API_KEY_PATH"] = fastlaneAuthFile
 		// deliver: "Precheck cannot check In-app purchases with the App Store Connect API Key (yet). Exclude In-app purchases from precheck"
 		envs["PRECHECK_INCLUDE_IN_APP_PURCHASES"] = "false"
 	}

--- a/credentials.go
+++ b/credentials.go
@@ -61,7 +61,7 @@ func FastlaneAuthParams(authConfig appleauth.Credentials) (map[string]string, er
 			return envs, err
 		}
 
-		envs["DELIVER_API_KEY_PATH"] = fastlaneAuthFile
+		envs["APP_STORE_CONNECT_API_KEY_PATH"] = fastlaneAuthFile
 		// deliver: "Precheck cannot check In-app purchases with the App Store Connect API Key (yet). Exclude In-app purchases from precheck"
 		envs["PRECHECK_INCLUDE_IN_APP_PURCHASES"] = "false"
 	}

--- a/credentials.go
+++ b/credentials.go
@@ -29,6 +29,7 @@ func FastlaneAuthParams(authConfig appleauth.Credentials) (map[string]string, er
 		if authConfig.AppleID.Username != "" {
 			envs["FASTLANE_USER"] = authConfig.AppleID.Username
 			envs["DELIVER_USERNAME"] = authConfig.AppleID.Username
+			envs["PILOT_USERNAME"] = authConfig.AppleID.Username
 		}
 		if authConfig.AppleID.Password != "" {
 			envs["FASTLANE_PASSWORD"] = authConfig.AppleID.Password


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires PATCH [version update](https://semver.org/)

### Context

Fastlane's environment variables for API Key Auth got unified.

Exporting to the new environment variable is also required to use API Key Auth with fastlane [pilot](https://docs.fastlane.tools/actions/pilot/)

### Changes

Export the path to the generated _api_key.json_ in the environment variable `APP_STORE_CONNECT_API_KEY_PATH`.

For compatiblilty with older fastlane versions (and pass this step's tests) the new variable is exported _in addition_ to existing variable `DELIVER_API_KEY_PATH`. Furthermore other old authentication related environment variables `PILOT_USERNAME` and `PILOT_API_KEY_PATH` get exported now. These should be removed in a later update.

### Investigation details

With this change API Key Auth will work both in [deliver](https://github.com/fastlane/fastlane/blob/master/deliver/lib/deliver/options.rb#L16) and in [pilot](https://github.com/fastlane/fastlane/blob/master/pilot/lib/pilot/options.rb#L14), too.

The [consolidation was beeing discussed](https://github.com/fastlane/fastlane/discussions/18145) in the fastlane comunity and got [released with 2.175.0](https://github.com/fastlane/fastlane/pull/18181) since.
