### PR TITLE
Replace deprecated code signing step in e2e workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -55,13 +55,13 @@ workflows:
         - work_dir: ./
         - verbose_log: "yes"
         - connection: apple_id
-    - ios-auto-provision-appstoreconnect:
+    - manage-ios-code-signing:
         run_if: "true"
         inputs:
         - project_path: ./ios/Runner.xcworkspace
         - scheme: $XCODE_SCHEME
         - configuration: Release
-        - distribution_type: development
+        - distribution_method: development
     - flutter-installer:
         run_if: "true"
         title: Install Flutter


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

No version update needed, as this is only fixing an e2e test.

### Context

One of the e2e tests is failing because it's using a deprecated Step.

### Changes

- Replaces the deprecated `ios-auto-provision-appstoreconnect` Step with the newer `manage-ios-code-signing` Step.