### PR TITLE
Fix Ruby version command

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -106,9 +106,7 @@ func (f FastlaneRunner) InstallDependencies(opts EnsureDependenciesOpts) error {
 func (f FastlaneRunner) reportRubyVersion(useBundler bool, bundlerVersion string, workDir string) {
 	var versionCmd command.Command
 	options := &command.Opts{
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-		Dir:    workDir,
+		Dir: workDir,
 	}
 	if useBundler {
 		versionCmd = f.rbyFactory.CreateBundleExec("ruby", []string{"--version"}, bundlerVersion, options)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Ruby version reporting got broken in the last commit of #95:

```
Determine desired Fastlane version
Gem lockfile does not exist
Failed to check active Ruby version: executing command failed (ruby "--version"): exec: Stdout already set
Output:
```

### Changes

Fix the command execution params. We don't need to set the stdout, it's enough to set the workdir.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
